### PR TITLE
Fix device group editing and selection logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -747,7 +747,12 @@ def device_groups():
 
     users = User.query.order_by(func.lower(User.last_name_token), func.lower(User.full_name), func.lower(User.username)).all()
     creators = User.query.order_by(func.lower(User.last_name_token), func.lower(User.full_name), func.lower(User.username)).all()
-    devices = Device.query.order_by(Device.device_code).all()
+    # Chỉ hiển thị thiết bị chưa thuộc bất kỳ nhóm nào để chọn
+    assigned_device_ids = [l.device_id for l in DeviceGroupDevice.query.all()]
+    if assigned_device_ids:
+        devices = Device.query.filter(~Device.id.in_(assigned_device_ids)).order_by(Device.device_code).all()
+    else:
+        devices = Device.query.order_by(Device.device_code).all()
     return render_template(
         'device_groups.html',
         group_summaries=group_summaries,
@@ -770,7 +775,12 @@ def device_group_detail(group_id):
     device_links = DeviceGroupDevice.query.filter_by(group_id=group_id).all()
     device_ids_in_group = [l.device_id for l in device_links] if device_links else []
     devices_in_group = Device.query.filter(Device.id.in_(device_ids_in_group)).order_by(Device.device_code).all() if device_ids_in_group else []
-    devices_not_in_group = Device.query.order_by(Device.device_code).all() if not device_ids_in_group else Device.query.filter(~Device.id.in_(device_ids_in_group)).order_by(Device.device_code).all()
+    # Thiết bị chưa thuộc bất kỳ nhóm nào (để đảm bảo 1 thiết bị chỉ ở 1 nhóm)
+    all_assigned_ids = [l.device_id for l in DeviceGroupDevice.query.all()]
+    if all_assigned_ids:
+        devices_not_in_group = Device.query.filter(~Device.id.in_(all_assigned_ids)).order_by(Device.device_code).all()
+    else:
+        devices_not_in_group = Device.query.order_by(Device.device_code).all()
     # Người dùng trong nhóm
     user_links = UserDeviceGroup.query.filter_by(group_id=group_id).all()
     user_ids_in_group = [l.user_id for l in user_links] if user_links else []
@@ -981,14 +991,60 @@ def assign_devices_to_group(group_id):
         return redirect(url_for('device_group_detail', group_id=group_id))
     created = 0
     for d_id in device_ids:
-        if not d_id: continue
-        exists = DeviceGroupDevice.query.filter_by(group_id=group_id, device_id=int(d_id)).first()
+        if not d_id:
+            continue
+        d_int = int(d_id)
+        # Gỡ khỏi nhóm cũ nếu đang thuộc nhóm khác (đảm bảo unique)
+        old_link = DeviceGroupDevice.query.filter_by(device_id=d_int).first()
+        if old_link and old_link.group_id != group_id:
+            db.session.delete(old_link)
+        exists = DeviceGroupDevice.query.filter_by(group_id=group_id, device_id=d_int).first()
         if not exists:
-            db.session.add(DeviceGroupDevice(group_id=group_id, device_id=int(d_id)))
+            db.session.add(DeviceGroupDevice(group_id=group_id, device_id=d_int))
             created += 1
     db.session.commit()
     flash(f'Đã thêm {created} thiết bị vào nhóm.', 'success')
     return redirect(url_for('device_group_detail', group_id=group_id))
+
+@app.route('/server_room', methods=['GET', 'POST'])
+def server_room():
+    if 'user_id' not in session: return redirect(url_for('login'))
+    # Tạo/lấy nhóm đặc biệt "Phòng server"
+    group = DeviceGroup.query.filter(func.lower(DeviceGroup.name) == func.lower('Phòng server')).first()
+    if not group:
+        group = DeviceGroup(name='Phòng server', description='Nhóm thiết bị phòng server', created_by=session.get('user_id'))
+        db.session.add(group)
+        db.session.commit()
+    if request.method == 'POST':
+        device_ids = request.form.getlist('device_ids')
+        created = 0
+        for d_id in device_ids:
+            if not d_id:
+                continue
+            d_int = int(d_id)
+            # đảm bảo unique: gỡ khỏi nhóm cũ
+            old_link = DeviceGroupDevice.query.filter_by(device_id=d_int).first()
+            if old_link and old_link.group_id != group.id:
+                db.session.delete(old_link)
+            exists = DeviceGroupDevice.query.filter_by(group_id=group.id, device_id=d_int).first()
+            if not exists:
+                db.session.add(DeviceGroupDevice(group_id=group.id, device_id=d_int))
+                created += 1
+        db.session.commit()
+        flash(f'Đã thêm {created} thiết bị vào Phòng server.', 'success')
+        return redirect(url_for('server_room'))
+
+    # Danh sách thiết bị trong phòng server
+    links = DeviceGroupDevice.query.filter_by(group_id=group.id).all()
+    ids_in_server = [l.device_id for l in links]
+    devices_in_server = Device.query.filter(Device.id.in_(ids_in_server)).order_by(Device.device_code).all() if ids_in_server else []
+    # Thiết bị sẵn có để thêm: chưa thuộc nhóm nào
+    all_assigned_ids = [l.device_id for l in DeviceGroupDevice.query.all()]
+    if all_assigned_ids:
+        devices_available = Device.query.filter(~Device.id.in_(all_assigned_ids)).order_by(Device.device_code).all()
+    else:
+        devices_available = Device.query.order_by(Device.device_code).all()
+    return render_template('server_room.html', group=group, devices_in_server=devices_in_server, devices_available=devices_available)
 
 @app.route('/device_groups/<int:group_id>/remove_device/<int:device_id>', methods=['POST'])
 def remove_device_from_group(group_id, device_id):

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,6 +26,7 @@
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('home') }}">Dashboard</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('device_list') }}">Thiết bị</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('device_groups') }}">Nhóm thiết bị</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('server_room') }}">Phòng server</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('user_list') }}">Người dùng</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('handover_list') }}">Bàn giao thiết bị</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('inventory_receipts') }}">Phiếu nhập kho</a></li>

--- a/templates/device_group_detail.html
+++ b/templates/device_group_detail.html
@@ -33,7 +33,39 @@
                 <div class="card mb-3">
                     <div class="card-header bg-light"><strong>Thiết bị trong nhóm</strong></div>
                     <div class="card-body">
-                        
+                        <form method="POST" action="{{ url_for('assign_devices_to_group', group_id=group.id) }}" class="mb-3">
+                            <label class="form-label">Thêm thiết bị vào nhóm</label>
+                            <div class="row g-2 mb-2">
+                                <div class="col-md-4"><input type="text" class="form-control" id="filter_code" placeholder="Lọc mã thiết bị"></div>
+                                <div class="col-md-4"><input type="text" class="form-control" id="filter_name" placeholder="Lọc tên thiết bị"></div>
+                                <div class="col-md-4">
+                                    <select class="form-select" id="filter_type">
+                                        <option value="">-- Loại thiết bị --</option>
+                                        <option value="Laptop">Laptop</option>
+                                        <option value="Case máy tính">Case máy tính</option>
+                                        <option value="Màn hình">Màn hình</option>
+                                        <option value="Bàn phím">Bàn phím</option>
+                                        <option value="Chuột">Chuột</option>
+                                        <option value="Ổ cứng">Ổ cứng</option>
+                                        <option value="Ram">Ram</option>
+                                        <option value="Card màn hình">Card màn hình</option>
+                                        <option value="Máy in">Máy in</option>
+                                        <option value="Thiết bị mạng">Thiết bị mạng</option>
+                                        <option value="Server">Server</option>
+                                        <option value="Thiết bị khác">Thiết bị khác</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <select name="device_ids" class="form-select" multiple size="7" id="devices_select">
+                                {% for device in devices_not_in_group %}
+                                <option value="{{ device.id }}" data-code="{{ device.device_code }}" data-name="{{ device.name }}" data-type="{{ device.device_type }}">{{ device.device_code }} - {{ device.name }} ({{ device.device_type }})</option>
+                                {% endfor %}
+                            </select>
+                            <div class="mt-2 text-end">
+                                <button class="btn btn-sm btn-outline-primary">Thêm</button>
+                            </div>
+                            <small class="text-muted">Chỉ hiển thị thiết bị chưa thuộc nhóm nào. Một thiết bị chỉ có thể thuộc một nhóm.</small>
+                        </form>
 
                         <div class="table-responsive">
                             <table class="table table-sm table-striped">

--- a/templates/device_groups.html
+++ b/templates/device_groups.html
@@ -19,7 +19,7 @@
             <div class="col-md-2"><label class="form-label">Từ ngày</label><input type="date" name="start_date" value="{{ filter_start_date }}" class="form-control"></div>
             <div class="col-md-2"><label class="form-label">Đến ngày</label><input type="date" name="end_date" value="{{ filter_end_date }}" class="form-control"></div>
             <div class="col-md-1"><label class="form-label">Người tạo</label><select name="created_by" class="form-select"><option value="">--</option>{% for c in creators %}<option value="{{ c.id }}" {% if filter_created_by==c.id|string %}selected{% endif %}>{{ c.full_name or c.username }}</option>{% endfor %}</select></div>
-            <div class="col-md-12"><button class="btn btn-primary">Lọc</button> <a href="{{ url_for('device_groups') }}" class="btn btn-secondary ms-2">Reset</a></div>
+            <div class="col-md-12"><button class="btn btn-primary">Lọc</button> <a href="{{ url_for('device_groups') }}" class="btn btn-secondary ms-2">Reset</a> <a href="{{ url_for('server_room') }}" class="btn btn-outline-dark ms-2">Phòng server</a></div>
         </form>
 
         <div class="table-responsive">
@@ -82,6 +82,38 @@
         </div>
     </div>
 </div>
+{% for item in group_summaries %}
+<div class="modal fade" id="editGroupModal-{{ item.group.id }}" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="POST" action="{{ url_for('edit_device_group', group_id=item.group.id) }}">
+        <div class="modal-header">
+          <h5 class="modal-title">Sửa nhóm</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">Tên nhóm</label>
+            <input name="name" class="form-control" value="{{ item.group.name }}" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Mô tả</label>
+            <input name="description" class="form-control" value="{{ item.group.description }}">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Ghi chú</label>
+            <input name="notes" class="form-control" value="{{ item.group.notes }}">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Hủy</button>
+          <button type="submit" class="btn btn-primary">Lưu</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endfor %}
 <div class="modal fade" id="createGroupModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">

--- a/templates/server_room.html
+++ b/templates/server_room.html
@@ -1,0 +1,111 @@
+{% extends "base.html" %}
+
+{% block title %}Phòng server{% endblock %}
+
+{% block content %}
+<div class="card">
+    <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <h2 class="card-title mb-0">Quản lý thiết bị Phòng server</h2>
+            <a href="{{ url_for('device_groups') }}" class="btn btn-secondary">Nhóm thiết bị</a>
+        </div>
+
+        <form method="POST" class="mb-3">
+            <label class="form-label">Thêm thiết bị từ kho vào Phòng server</label>
+            <div class="row g-2 mb-2">
+                <div class="col-md-4"><input type="text" class="form-control" id="filter_code" placeholder="Lọc mã thiết bị"></div>
+                <div class="col-md-4"><input type="text" class="form-control" id="filter_name" placeholder="Lọc tên thiết bị"></div>
+                <div class="col-md-4">
+                    <select class="form-select" id="filter_type">
+                        <option value="">-- Loại thiết bị --</option>
+                        <option value="Laptop">Laptop</option>
+                        <option value="Case máy tính">Case máy tính</option>
+                        <option value="Màn hình">Màn hình</option>
+                        <option value="Bàn phím">Bàn phím</option>
+                        <option value="Chuột">Chuột</option>
+                        <option value="Ổ cứng">Ổ cứng</option>
+                        <option value="Ram">Ram</option>
+                        <option value="Card màn hình">Card màn hình</option>
+                        <option value="Máy in">Máy in</option>
+                        <option value="Thiết bị mạng">Thiết bị mạng</option>
+                        <option value="Server">Server</option>
+                        <option value="Thiết bị khác">Thiết bị khác</option>
+                    </select>
+                </div>
+            </div>
+            <select name="device_ids" id="devices_select" multiple class="form-select" size="8">
+                {% for device in devices_available %}
+                <option value="{{ device.id }}" data-code="{{ device.device_code }}" data-name="{{ device.name }}" data-type="{{ device.device_type }}">{{ device.device_code }} - {{ device.name }} ({{ device.device_type }})</option>
+                {% endfor %}
+            </select>
+            <div class="mt-2 text-end">
+                <button class="btn btn-primary">Thêm vào phòng server</button>
+            </div>
+            <small class="text-muted">Thiết bị đã thuộc nhóm khác sẽ không hiển thị. Mỗi thiết bị chỉ thuộc một nhóm.</small>
+        </form>
+
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead class="table-light">
+                    <tr>
+                        <th>STT</th>
+                        <th>Tên thiết bị</th>
+                        <th>Mã thiết bị</th>
+                        <th>Cấu hình</th>
+                        <th>Ngày cập nhật</th>
+                        <th>Người quản lý</th>
+                        <th>Trạng thái</th>
+                        <th>Chạy dịch vụ</th>
+                        <th>IP</th>
+                        <th>Ghi chú</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for d in devices_in_server %}
+                    <tr>
+                        <td>{{ loop.index }}</td>
+                        <td>{{ d.name }}</td>
+                        <td>{{ d.device_code }}</td>
+                        <td><div class="text-truncate" style="max-width: 260px;">{{ d.configuration }}</div></td>
+                        <td>{{ d.created_at.strftime('%Y-%m-%d') if d.created_at else '' }}</td>
+                        <td>{{ d.manager.full_name if d.manager else '' }}</td>
+                        <td>{{ d.status }}</td>
+                        <td><!-- Chạy dịch vụ: chưa có field, để trống --></td>
+                        <td><!-- IP: chưa có field, để trống --></td>
+                        <td>{{ d.notes }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const codeInput = document.getElementById('filter_code');
+    const nameInput = document.getElementById('filter_name');
+    const typeSelect = document.getElementById('filter_type');
+    const selectEl = document.getElementById('devices_select');
+    function applyFilter() {
+        const code = (codeInput?.value || '').toLowerCase();
+        const name = (nameInput?.value || '').toLowerCase();
+        const type = (typeSelect?.value || '').toLowerCase();
+        Array.from(selectEl.options).forEach(o => {
+            const oc = (o.dataset.code || '').toLowerCase();
+            const on = (o.dataset.name || '').toLowerCase();
+            const ot = (o.dataset.type || '').toLowerCase();
+            const match = (!code || oc.includes(code)) && (!name || on.includes(name)) && (!type || ot === type);
+            o.hidden = !match;
+        });
+    }
+    codeInput?.addEventListener('input', applyFilter);
+    nameInput?.addEventListener('input', applyFilter);
+    typeSelect?.addEventListener('change', applyFilter);
+});
+</script>
+{% endblock %}
+


### PR DESCRIPTION
Fix device group editing, enforce one device per group, and add a "Phòng server" management tab.

This PR addresses a bug preventing device group edits and implements the requested business logic that a device can only belong to one group. It also introduces a new "Phòng server" tab for dedicated server room device management, allowing assignment of unassigned devices and displaying a custom table with specified columns.

---
<a href="https://cursor.com/background-agent?bcId=bc-32eb9857-d836-4a2a-8405-e5576624b758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-32eb9857-d836-4a2a-8405-e5576624b758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

